### PR TITLE
Add support for Compute Modules

### DIFF
--- a/boardtype/raspberrypi.go
+++ b/boardtype/raspberrypi.go
@@ -13,9 +13,17 @@ var (
 	RaspberryPi4B4GB  = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "4B", RAM: 4096, BaseModel: &RaspberryPi4B}
 	RaspberryPi4B8GB  = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "4B", RAM: 8192, BaseModel: &RaspberryPi4B}
 	RaspberryPi4400   = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "4 400", RAM: 4096, BaseModel: &RaspberryPi4B}
+	RaspberryPiCM41GB = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "Compute Module 4", RAM: 1024, BaseModel: &RaspberryPi4B}
+	RaspberryPiCM42GB = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "Compute Module 4", RAM: 2048, BaseModel: &RaspberryPi4B}
+	RaspberryPiCM44GB = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "Compute Module 4", RAM: 4096, BaseModel: &RaspberryPi4B}
+	RaspberryPiCM48GB = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "Compute Module 4", RAM: 8192, BaseModel: &RaspberryPi4B}
 	RaspberryPi5      = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "", RAM: 0, BaseModel: &RaspberryPi}
 	RaspberryPi5B     = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "5B", RAM: 0, BaseModel: &RaspberryPi5}
 	RaspberryPi5B2GB  = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "5B", RAM: 2048, BaseModel: &RaspberryPi5B}
 	RaspberryPi5B4GB  = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "5B", RAM: 4096, BaseModel: &RaspberryPi5B}
 	RaspberryPi5B8GB  = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "5B", RAM: 8192, BaseModel: &RaspberryPi5B}
+	RaspberryPiCM51GB = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "Compute Module 5", RAM: 1024, BaseModel: &RaspberryPi5B}
+	RaspberryPiCM52GB = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "Compute Module 5", RAM: 2048, BaseModel: &RaspberryPi5B}
+	RaspberryPiCM54GB = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "Compute Module 5", RAM: 4096, BaseModel: &RaspberryPi5B}
+	RaspberryPiCM58GB = BoardType{Manufacturer: "Raspberry Pi", Model: "Raspberry Pi", SubModel: "Compute Module 5", RAM: 8192, BaseModel: &RaspberryPi5B}
 )

--- a/boardtype/raspberrypi/raspberrypi.go
+++ b/boardtype/raspberrypi/raspberrypi.go
@@ -38,10 +38,18 @@ var raspberryPiModels = []raspberryPi{
 	{"Raspberry Pi 4 Model B", 2048, boardtype.RaspberryPi4B2GB, boardtype.RaspberryPi4B},
 	{"Raspberry Pi 4 Model B", 4096, boardtype.RaspberryPi4B4GB, boardtype.RaspberryPi4B},
 	{"Raspberry Pi 4 Model B", 8192, boardtype.RaspberryPi4B8GB, boardtype.RaspberryPi4B},
+	{"Raspberry Pi Compute Module 4", 1024, boardtype.RaspberryPiCM41GB, boardtype.RaspberryPi4B},
+	{"Raspberry Pi Compute Module 4", 2048, boardtype.RaspberryPiCM42GB, boardtype.RaspberryPi4B},
+	{"Raspberry Pi Compute Module 4", 4096, boardtype.RaspberryPiCM44GB, boardtype.RaspberryPi4B},
+	{"Raspberry Pi Compute Module 4", 8192, boardtype.RaspberryPiCM48GB, boardtype.RaspberryPi4B},
 	{"Raspberry Pi 400", 4096, boardtype.RaspberryPi4400, boardtype.RaspberryPi4400},
 	{"Raspberry Pi 5 Model B", 2048, boardtype.RaspberryPi5B2GB, boardtype.RaspberryPi5B},
 	{"Raspberry Pi 5 Model B", 4096, boardtype.RaspberryPi5B4GB, boardtype.RaspberryPi5B},
 	{"Raspberry Pi 5 Model B", 8192, boardtype.RaspberryPi5B8GB, boardtype.RaspberryPi5B},
+	{"Raspberry Pi Compute Module 5", 1024, boardtype.RaspberryPiCM51GB, boardtype.RaspberryPi5B},
+	{"Raspberry Pi Compute Module 5", 2048, boardtype.RaspberryPiCM52GB, boardtype.RaspberryPi5B},
+	{"Raspberry Pi Compute Module 5", 4096, boardtype.RaspberryPiCM54GB, boardtype.RaspberryPi5B},
+	{"Raspberry Pi Compute Module 5", 8192, boardtype.RaspberryPiCM58GB, boardtype.RaspberryPi5B},
 }
 
 func NewRaspberryPiIdentifier(logger *slog.Logger) identifier.BoardIdentifier {


### PR DESCRIPTION
This PR adds support for Raspberry Pi Compute Modules CM4 / CM5
This will allow viam-sbc-hwmon to report status of Raspberry Pi Compute Module devices.
Fixes https://github.com/rinzlerlabs/sbcidentify/issues/2